### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,6 @@ commands=
 basepython= python3.7
 deps=
     pytest-astropy
-    codecov
 conda_deps=
     pytest
     coverage
@@ -61,5 +60,7 @@ commands=
     coverage run --source=jwstinfo --rcfile={toxinidir}/jwstinfo/tests/coveragerc \
                  -m pytest --remote-data --open-files
     coverage report -m
-    codecov -e TOXENV
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    ./codecov -e TOXENV
 passenv= TOXENV CI TRAVIS TRAVIS_* CODECOV_* DISPLAY


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI